### PR TITLE
Update wallet_api build w/ diardi

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -136,7 +136,8 @@ if (BUILD_GUI_DEPS)
             checkpoints
             version
             net
-            device_trezor)
+            device_trezor
+            diardi)
 
     foreach(lib ${libs_to_merge})
         list(APPEND objlibs $<TARGET_OBJECTS:obj_${lib}>) # matches naming convention in src/CMakeLists.txt


### PR DESCRIPTION
When using merged lib error on diardi not found

```
Undefined symbols for architecture arm64:
  "cryptonote::Diardi::get_checkpoints(cryptonote::network_type, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)"
```