### PR TITLE
depends: remove missing fix-android.patch and eudev dependency

### DIFF
--- a/contrib/depends/packages/hidapi.mk
+++ b/contrib/depends/packages/hidapi.mk
@@ -3,7 +3,7 @@ $(package)_version=0.15.0
 $(package)_download_path=https://github.com/libusb/hidapi/archive/refs/tags
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=5d84dec684c27b97b921d2f3b73218cb773cf4ea915caee317ac8fc73cef8136
-$(package)_linux_dependencies=libusb eudev
+$(package)_linux_dependencies=libusb
 
 define $(package)_set_vars
   $(package)_config_opts := -DBUILD_SHARED_LIBS=OFF

--- a/contrib/depends/packages/openssl.mk
+++ b/contrib/depends/packages/openssl.mk
@@ -49,8 +49,7 @@ $(package)_config_opts_x86_64_freebsd=BSD-x86_64
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old 's|crypto ssl apps util tools fuzz providers doc|crypto ssl util tools providers|' build.info && \
-  patch -p1 < $($(package)_patch_dir)/fix-android.patch
+  sed -i.old 's|crypto ssl apps util tools fuzz providers doc|crypto ssl util tools providers|' build.info
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
## Summary
This PR fixes two issues that were breaking the `depends` build for multiple targets:

**Missing `fix-android.patch`** – The `openssl.mk` tried to apply a patch that does not exist in the repository, causing the build to fail with:
   ```
   /bin/sh: cannot open .../fix-android.patch: No such file
   ```
   This PR removes the patch application line, aligning `openssl.mk` with upstream Monero (which no longer uses this patch).

**Missing `eudev` dependency** – The `hidapi.mk` listed `eudev` as a dependency, but `eudev.mk` does not exist in the repo. This PR removes `eudev` from the dependencies list, matching upstream Monero where `hidapi` only depends on `libusb`.